### PR TITLE
Added Maven as a repository for the Gradle dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 repositories {
+    mavenCentral()
 }
 
 /**


### PR DESCRIPTION
In our project, Gradle was unable to locate the dependencies of the Abound SDK. Adding `mavenCentral()` as a repository fixed this issue for us. The Abound SDK was added as a module to our project via the "Import Module" method in the [README](https://github.com/withabound/abound-android-client-sdk#installation).

Maybe this is just an issue with how our project is set up. Wanted to share what worked for us.